### PR TITLE
Laravel v6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ composer require kojirock5260/laravel-json-schema-validate
 ```
 
 ```bash
-php artisan vendor:publish --provider=Kojirock5260\\JsonSchemaServiceProvider
+php artisan vendor:publish --provider=Kojirock5260\\JsonSchemaValidate\\JsonSchemaServiceProvider
 ```
 
 ## Setup

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "php": "^7.2",
+    "php": "^7.3",
     "justinrainbow/json-schema": "^5.2.8",
     "illuminate/support":        "^5.7|^6.0",
     "illuminate/http":           "^5.7|^6.0",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "php": "^7.3",
+    "php": "^7.1",
     "justinrainbow/json-schema": "^5.2.8",
     "illuminate/support":        "^5.7|^6.0",
     "illuminate/http":           "^5.7|^6.0",

--- a/composer.json
+++ b/composer.json
@@ -10,14 +10,14 @@
     }
   ],
   "require": {
-    "php": ">=7",
+    "php": "^7.2",
     "justinrainbow/json-schema": "^5.2.8",
-    "illuminate/support":        "5.7.x|5.8.x",
-    "illuminate/http":           "5.7.x|5.8.x",
-    "illuminate/routing":        "5.7.x|5.8.x"
+    "illuminate/support":        "^5.7|^6.0",
+    "illuminate/http":           "^5.7|^6.0",
+    "illuminate/routing":        "^5.7|^6.0"
   },
   "require-dev": {
-    "laravel/framework": "^5.8",
+    "laravel/framework": "^5.8|^6.0",
     "squizlabs/php_codesniffer": "^2.3"
   },
   "autoload": {

--- a/src/Exception/JsonSchemaException.php
+++ b/src/Exception/JsonSchemaException.php
@@ -29,7 +29,7 @@ class JsonSchemaException extends HttpException
     public function getJsonErrorMessage(): string
     {
         $results     = [];
-        $messageList = unserialize($this->getMessage());
+        $messageList = unserialize($this->getMessage(), null);
 
         foreach ($messageList as $v) {
             $results[] = $v['message'];

--- a/src/Exception/JsonSchemaException.php
+++ b/src/Exception/JsonSchemaException.php
@@ -29,7 +29,7 @@ class JsonSchemaException extends HttpException
     public function getJsonErrorMessage(): string
     {
         $results     = [];
-        $messageList = unserialize($this->getMessage(), null);
+        $messageList = unserialize($this->getMessage());
 
         foreach ($messageList as $v) {
             $results[] = $v['message'];


### PR DESCRIPTION
This PR is support for laravel6.
And I changed support PHP version, because over PHP 7.1 supported `void functions`

